### PR TITLE
Hand apply some more changes from blockly flyout.js to flyout_base.js.

### DIFF
--- a/core/field_variable.js
+++ b/core/field_variable.js
@@ -29,7 +29,6 @@ goog.provide('Blockly.FieldVariable');
 goog.require('Blockly.FieldDropdown');
 goog.require('Blockly.Msg');
 goog.require('Blockly.Variables');
-goog.require('goog.asserts');
 goog.require('goog.string');
 
 
@@ -86,16 +85,6 @@ Blockly.FieldVariable.prototype.init = function() {
   if (!this.sourceBlock_.isInFlyout) {
     this.sourceBlock_.workspace.createVariable(this.getValue());
   }
-};
-
-/**
- * Attach this field to a block.
- * @param {!Blockly.Block} block The block containing this field.
- */
-Blockly.FieldVariable.prototype.setSourceBlock = function(block) {
-  goog.asserts.assert(!block.isShadow(),
-      'Variable fields are not allowed to exist on shadow blocks.');
-  Blockly.FieldVariable.superClass_.setSourceBlock.call(this, block);
 };
 
 /**

--- a/core/flyout_base.js
+++ b/core/flyout_base.js
@@ -488,6 +488,7 @@ Blockly.Flyout.prototype.hide = function() {
  *     Variables and procedures have a custom set of blocks.
  */
 Blockly.Flyout.prototype.show = function(xmlList) {
+  this.workspace_.setResizesEnabled(false);
   this.hide();
   this.clearOldBlocks_();
 
@@ -537,10 +538,8 @@ Blockly.Flyout.prototype.show = function(xmlList) {
       } else if (tagName == 'BUTTON' || tagName == 'LABEL') {
         // Labels behave the same as buttons, but are styled differently.
         var isLabel = tagName == 'LABEL';
-        var text = xml.getAttribute('text');
-        var callbackKey = xml.getAttribute('callbackKey');
         var curButton = new Blockly.FlyoutButton(this.workspace_,
-            this.targetWorkspace_, text, callbackKey, isLabel);
+            this.targetWorkspace_, xml, isLabel);
         contents.push({type: 'button', button: curButton});
         gaps.push(default_gap);
       }
@@ -845,6 +844,10 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
       return;
     }
     Blockly.Events.disable();
+    // Disable workspace resizing. Reenable at the end of the drag. This avoids
+    // a spurious resize between creating the new block and placing it in the
+    // workspace.
+    flyout.targetWorkspace_.setResizesEnabled(false);
     try {
       var block = flyout.placeNewBlock_(originBlock);
     } finally {
@@ -862,8 +865,6 @@ Blockly.Flyout.prototype.createBlockFunc_ = function(originBlock) {
     Blockly.dragMode_ = Blockly.DRAG_FREE;
     block.setDragging_(true);
     block.moveToDragSurface_();
-    // Disable workspace resizing.  Reenable at the end of the drag.
-    flyout.targetWorkspace_.setResizesEnabled(false);
   };
 };
 

--- a/core/xml.js
+++ b/core/xml.js
@@ -551,9 +551,6 @@ Blockly.Xml.domToBlockHeadless_ = function(xmlBlock, workspace) {
       goog.asserts.assert(child.isShadow(),
                           'Shadow block not allowed non-shadow child.');
     }
-    // Ensure this block doesn't have any variable inputs.
-    goog.asserts.assert(block.getVars().length == 0,
-        'Shadow blocks cannot have variable fields.');
     block.setShadow(true);
   }
   return block;


### PR DESCRIPTION
Also revert https://github.com/google/blockly/commit/08efd1381c575f304d000e44060135e35f7ed013
in scratch-blocks since it breaks variables and there is more work fenichel is planning
to do here.

(note that the Data category should work again)